### PR TITLE
feat(scm): implement GitHub PR automation

### DIFF
--- a/libs/persistence/src/index.ts
+++ b/libs/persistence/src/index.ts
@@ -1,4 +1,11 @@
-import type { Finding, ID, Run } from '@accessmate/core-types';
+import type { Finding, ID, Installation, PRRef, Project, Run } from '@accessmate/core-types';
+
+export interface SuggestedFileChange {
+  path: string;
+  content: string;
+  encoding?: 'utf-8' | 'base64';
+  mode?: '100644' | '100755';
+}
 
 type CreateRunInput = {
   id: ID;
@@ -17,6 +24,12 @@ type UpdateRunInput = Partial<Omit<Run, 'id' | 'projectId' | 'trigger'>> & {
 
 const runs = new Map<ID, Run>();
 const findingsByRun = new Map<ID, Finding[]>();
+const projects = new Map<ID, Project>();
+const installations = new Map<ID, Installation>();
+const installationsByOrg = new Map<ID, Installation>();
+const suggestedFileChangesByFinding = new Map<ID, SuggestedFileChange[]>();
+const prRefs = new Map<ID, PRRef>();
+const prRefsByProject = new Map<ID, PRRef[]>();
 
 export function createRun(input: CreateRunInput): Run {
   const run: Run = {
@@ -75,4 +88,58 @@ export function getFindings(runId: ID): Finding[] {
 export function resetStore(): void {
   runs.clear();
   findingsByRun.clear();
+  projects.clear();
+  installations.clear();
+  installationsByOrg.clear();
+  suggestedFileChangesByFinding.clear();
+  prRefs.clear();
+  prRefsByProject.clear();
+}
+
+export function saveProject(project: Project): Project {
+  projects.set(project.id, project);
+  return project;
+}
+
+export function getProject(id: ID): Project | undefined {
+  return projects.get(id);
+}
+
+export function saveInstallation(installation: Installation): Installation {
+  installations.set(installation.id, installation);
+  installationsByOrg.set(installation.orgId, installation);
+  return installation;
+}
+
+export function getInstallationByOrgId(orgId: ID): Installation | undefined {
+  return installationsByOrg.get(orgId);
+}
+
+export function getInstallation(id: ID): Installation | undefined {
+  return installations.get(id);
+}
+
+export function saveSuggestedFileChanges(findingId: ID, files: SuggestedFileChange[]): void {
+  suggestedFileChangesByFinding.set(findingId, files);
+}
+
+export function getSuggestedFileChanges(findingId: ID): SuggestedFileChange[] {
+  return suggestedFileChangesByFinding.get(findingId) ?? [];
+}
+
+export function savePRRef(ref: PRRef): PRRef {
+  prRefs.set(ref.id, ref);
+  const existing = prRefsByProject.get(ref.projectId) ?? [];
+  const idx = existing.findIndex((item) => item.id === ref.id);
+  if (idx >= 0) {
+    existing[idx] = ref;
+  } else {
+    existing.push(ref);
+  }
+  prRefsByProject.set(ref.projectId, existing);
+  return ref;
+}
+
+export function listPRRefs(projectId: ID): PRRef[] {
+  return [...(prRefsByProject.get(projectId) ?? [])];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@accessmate/queue':
         specifier: workspace:*
         version: link:../../libs/queue
+      '@accessmate/scm':
+        specifier: workspace:*
+        version: link:../scm
     devDependencies:
       tsx:
         specifier: ^4.17.0
@@ -265,6 +268,25 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.9.2
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.17)
+
+  services/scm:
+    dependencies:
+      '@accessmate/diagnostics':
+        specifier: workspace:*
+        version: link:../../libs/diagnostics
+      '@accessmate/github':
+        specifier: workspace:*
+        version: link:../../libs/github
+    devDependencies:
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.17)
 
 packages:
 

--- a/services/orchestrator/package.json
+++ b/services/orchestrator/package.json
@@ -5,17 +5,20 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "tsx src/worker.ts",
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
   },
   "dependencies": {
     "@accessmate/dynamic-audit": "workspace:*",
     "@accessmate/diagnostics": "workspace:*",
     "@accessmate/persistence": "workspace:*",
     "@accessmate/queue": "workspace:*",
-    "@accessmate/core-types": "workspace:*"
+    "@accessmate/core-types": "workspace:*",
+    "@accessmate/scm": "workspace:*"
   },
   "devDependencies": {
     "tsx": "^4.17.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.9"
   }
 }

--- a/services/orchestrator/src/worker.test.ts
+++ b/services/orchestrator/src/worker.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { randomUUID } from 'node:crypto';
+
+const infoMock = vi.fn();
+const warnMock = vi.fn();
+const errorMock = vi.fn();
+
+vi.mock(
+  '@accessmate/diagnostics',
+  () => ({
+    log: {
+      info: infoMock,
+      warn: warnMock,
+      error: errorMock,
+    },
+  }),
+  { virtual: true },
+);
+
+const queueAddMock = vi.fn();
+let workerHandler: ((job: unknown) => Promise<void>) | undefined;
+
+vi.mock(
+  '@accessmate/queue',
+  () => ({
+    createJobQueue: vi.fn(() => ({ add: queueAddMock })),
+    createJobWorker: vi.fn((handler: any) => {
+      workerHandler = handler;
+      return {};
+    }),
+    queueJobSchema: {
+      safeParse: (value: unknown) => ({ success: true, data: value }),
+    },
+    assertQueueJob: <T>(input: T) => input,
+  }),
+  { virtual: true },
+);
+
+const openPRMock = vi.fn();
+
+vi.mock(
+  '@accessmate/scm',
+  () => ({
+    openPR: (...args: unknown[]) => openPRMock(...args),
+  }),
+  { virtual: true },
+);
+
+import { listPRRefs, resetStore, saveInstallation, saveProject, saveSuggestedFileChanges } from '@accessmate/persistence';
+
+function buildJob(data: unknown) {
+  return {
+    id: 'job-123',
+    data,
+  } as any;
+}
+
+describe('worker pr.open handling', () => {
+  beforeAll(async () => {
+    await import('./worker.js');
+    if (!workerHandler) {
+      throw new Error('Worker handler was not registered');
+    }
+  });
+
+  beforeEach(() => {
+    resetStore();
+    queueAddMock.mockReset();
+    openPRMock.mockReset();
+    infoMock.mockReset();
+    warnMock.mockReset();
+    errorMock.mockReset();
+  });
+
+  afterEach(() => {
+    resetStore();
+  });
+
+  it('opens a PR and persists the reference', async () => {
+    const project = saveProject({
+      id: 'project-1',
+      orgId: 'org-1',
+      repoFullName: 'acme/widgets',
+      defaultBranch: 'main',
+    });
+    saveInstallation({ id: 'installation-1', orgId: 'org-1', githubInstallationId: 1234 });
+
+    const findingId = randomUUID();
+    saveSuggestedFileChanges(findingId, [{ path: 'README.md', content: 'updated content' }]);
+
+    openPRMock.mockResolvedValueOnce({
+      pullRequest: { number: 42, url: 'http://example/pr', branch: 'accessmate/job-123', headSha: 'sha' },
+    });
+
+    await workerHandler!(
+      buildJob({ kind: 'pr.open', projectId: project.id, findingIds: [findingId] }),
+    );
+
+    expect(openPRMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: 'acme/widgets',
+        branch: 'accessmate/job-123',
+        baseBranch: 'main',
+        installationId: 1234,
+        files: [{ path: 'README.md', content: 'updated content' }],
+        commitMessage: 'chore: apply 1 accessibility fix',
+      }),
+    );
+    expect(infoMock).toHaveBeenCalledWith('Pull request opened', {
+      projectId: 'project-1',
+      prNumber: 42,
+      branch: 'accessmate/job-123',
+    });
+
+    const prRefs = listPRRefs(project.id);
+    expect(prRefs).toHaveLength(1);
+    expect(prRefs[0]).toMatchObject({
+      projectId: project.id,
+      prNumber: 42,
+      branch: 'accessmate/job-123',
+    });
+  });
+
+  it('logs an error when installation is missing', async () => {
+    const project = saveProject({
+      id: 'project-2',
+      orgId: 'org-2',
+      repoFullName: 'acme/site',
+      defaultBranch: 'main',
+    });
+    const findingId = randomUUID();
+    saveSuggestedFileChanges(findingId, [{ path: 'README.md', content: 'updated content' }]);
+
+    await workerHandler!(
+      buildJob({ kind: 'pr.open', projectId: project.id, findingIds: [findingId] }),
+    );
+
+    expect(openPRMock).not.toHaveBeenCalled();
+    expect(errorMock).toHaveBeenCalledWith('No installation found for project', {
+      projectId: 'project-2',
+      orgId: 'org-2',
+    });
+    expect(listPRRefs(project.id)).toHaveLength(0);
+  });
+});

--- a/services/orchestrator/src/worker.ts
+++ b/services/orchestrator/src/worker.ts
@@ -4,7 +4,15 @@ import { Job } from 'bullmq';
 import { log } from '@accessmate/diagnostics';
 import type { Finding } from '@accessmate/core-types';
 import { runAudit } from '@accessmate/dynamic-audit';
-import { getRun, saveFindings, updateRun } from '@accessmate/persistence';
+import {
+  getInstallationByOrgId,
+  getProject,
+  getRun,
+  getSuggestedFileChanges,
+  saveFindings,
+  savePRRef,
+  updateRun,
+} from '@accessmate/persistence';
 import {
   assertQueueJob,
   createJobQueue,
@@ -12,6 +20,7 @@ import {
   queueJobSchema,
   type QueueJob,
 } from '@accessmate/queue';
+import { openPR } from '@accessmate/scm';
 
 const queue = createJobQueue();
 
@@ -127,7 +136,68 @@ createJobWorker(
         return;
       }
       case 'pr.open': {
-        log.info('pr.open job received (not yet implemented)', { projectId: data.projectId });
+        const project = getProject(data.projectId);
+        if (!project) {
+          log.warn('Received pr.open for unknown project', { projectId: data.projectId });
+          return;
+        }
+
+        const installation = getInstallationByOrgId(project.orgId);
+        if (!installation) {
+          log.error('No installation found for project', { projectId: project.id, orgId: project.orgId });
+          return;
+        }
+
+        const fileChanges = data.findingIds.flatMap((findingId) => getSuggestedFileChanges(findingId));
+        if (fileChanges.length === 0) {
+          log.warn('No file changes available for findings', { projectId: project.id, findingIds: data.findingIds });
+          return;
+        }
+
+        const branchSeed = typeof job.id === 'string' ? job.id : data.findingIds[0];
+        const branchSlug = branchSeed
+          ? branchSeed
+              .toLowerCase()
+              .replace(/[^a-z0-9-]/g, '-')
+              .replace(/-+/g, '-')
+              .replace(/^-|-$/g, '')
+          : undefined;
+        const branch = `accessmate/${branchSlug && branchSlug.length > 0 ? branchSlug : randomUUID()}`;
+        const changeCount = fileChanges.length;
+
+        try {
+          const pr = await openPR({
+            repo: project.repoFullName,
+            branch,
+            baseBranch: project.defaultBranch,
+            installationId: installation.githubInstallationId,
+            title: `Accessibility fixes (${data.findingIds.length} findings)`,
+            body: `This PR addresses ${data.findingIds.length} accessibility findings detected by AccessMate.`,
+            commitMessage: `chore: apply ${changeCount} accessibility ${changeCount === 1 ? 'fix' : 'fixes'}`,
+            files: fileChanges,
+          });
+
+          savePRRef({
+            id: randomUUID(),
+            projectId: project.id,
+            provider: 'github',
+            repo: project.repoFullName,
+            prNumber: pr.pullRequest.number,
+            branch: pr.pullRequest.branch,
+            status: 'open',
+          });
+
+          log.info('Pull request opened', {
+            projectId: project.id,
+            prNumber: pr.pullRequest.number,
+            branch: pr.pullRequest.branch,
+          });
+        } catch (error) {
+          log.error('Failed to open pull request for project', {
+            projectId: project.id,
+            error: error instanceof Error ? error.message : 'unknown error',
+          });
+        }
         return;
       }
     }

--- a/services/orchestrator/vitest.config.ts
+++ b/services/orchestrator/vitest.config.ts
@@ -1,0 +1,22 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const resolvePath = (...segments: string[]) =>
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), ...segments);
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@accessmate/core-types': resolvePath('../../libs/core-types/src/index.ts'),
+      '@accessmate/diagnostics': resolvePath('../../libs/diagnostics/src/index.ts'),
+      '@accessmate/dynamic-audit': resolvePath('../dynamic-audit/src/index.ts'),
+      '@accessmate/persistence': resolvePath('../../libs/persistence/src/index.ts'),
+      '@accessmate/queue': resolvePath('../../libs/queue/src/index.ts'),
+      '@accessmate/scm': resolvePath('../scm/src/index.ts'),
+    },
+  },
+});

--- a/services/scm/package.json
+++ b/services/scm/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@accessmate/scm",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@accessmate/diagnostics": "workspace:*",
+    "@accessmate/github": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.9"
+  }
+}

--- a/services/scm/src/index.test.ts
+++ b/services/scm/src/index.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+  return {
+    logError: vi.fn(),
+    createGitHubAppMock: vi.fn(),
+    createInstallationClientMock: vi.fn(),
+  };
+});
+
+vi.mock(
+  '@accessmate/diagnostics',
+  () => ({
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: (...args: unknown[]) => hoisted.logError(...args),
+    },
+  }),
+  { virtual: true },
+);
+
+vi.mock(
+  '@accessmate/github',
+  () => ({
+    createGitHubApp: (...args: unknown[]) => hoisted.createGitHubAppMock(...args),
+    createInstallationClient: (...args: unknown[]) => hoisted.createInstallationClientMock(...args),
+  }),
+  { virtual: true },
+);
+
+const { logError, createGitHubAppMock, createInstallationClientMock } = hoisted;
+
+import { openPR, type OpenPROptions } from './index.js';
+
+describe('openPR', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GH_APP_ID = '123';
+    process.env.GH_APP_PRIVATE_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  function createOctokitMocks() {
+    const getRef = vi.fn();
+    const getCommit = vi.fn();
+    const createBlob = vi.fn();
+    const createTree = vi.fn();
+    const createCommit = vi.fn();
+    const createRef = vi.fn();
+    const updateRef = vi.fn();
+    const pullsCreate = vi.fn();
+    const pullsList = vi.fn();
+
+    const octokit = {
+      git: { getRef, getCommit, createBlob, createTree, createCommit, createRef, updateRef },
+      pulls: { create: pullsCreate, list: pullsList },
+    } as const;
+
+    createInstallationClientMock.mockResolvedValueOnce(octokit);
+    createGitHubAppMock.mockReturnValueOnce({});
+
+    return { octokit, getRef, getCommit, createBlob, createTree, createCommit, createRef, updateRef, pullsCreate, pullsList };
+  }
+
+  function buildOptions(overrides: Partial<OpenPROptions> = {}): OpenPROptions {
+    return {
+      repo: 'acme/widgets',
+      branch: 'accessmate/test',
+      baseBranch: 'main',
+      installationId: 42,
+      title: 'Test PR',
+      body: 'Body',
+      commitMessage: 'chore: test',
+      files: [{ path: 'README.md', content: 'updated' }],
+      ...overrides,
+    };
+  }
+
+  it('creates a new branch and pull request when branch is missing', async () => {
+    const { octokit, getRef, getCommit, createBlob, createTree, createCommit, createRef, pullsCreate } = createOctokitMocks();
+
+    getRef
+      .mockResolvedValueOnce({ data: { object: { sha: 'base-sha' } } })
+      .mockRejectedValueOnce(Object.assign(new Error('missing'), { status: 404 }))
+      .mockRejectedValueOnce(Object.assign(new Error('missing'), { status: 404 }));
+    getCommit
+      .mockResolvedValueOnce({ data: { tree: { sha: 'base-tree' } } })
+      .mockResolvedValueOnce({ data: { tree: { sha: 'base-tree' } } });
+    createBlob.mockResolvedValueOnce({ data: { sha: 'blob-sha' } });
+    createTree.mockResolvedValueOnce({ data: { sha: 'new-tree' } });
+    createCommit.mockResolvedValueOnce({ data: { sha: 'commit-sha' } });
+    createRef.mockResolvedValueOnce({});
+    pullsCreate.mockResolvedValueOnce({ data: { number: 7, html_url: 'http://example/pr', head: { ref: 'accessmate/test' } } });
+
+    const result = await openPR(buildOptions());
+
+    expect(createGitHubAppMock).toHaveBeenCalledWith({ appId: 123, privateKey: 'test-key' });
+    expect(createInstallationClientMock).toHaveBeenCalledWith({ app: {}, installationId: 42 });
+    expect(createBlob).toHaveBeenCalledWith({ owner: 'acme', repo: 'widgets', content: 'updated', encoding: 'utf-8' });
+    expect(createTree).toHaveBeenCalledWith({
+      owner: 'acme',
+      repo: 'widgets',
+      base_tree: 'base-tree',
+      tree: [{ path: 'README.md', mode: '100644', type: 'blob', sha: 'blob-sha' }],
+    });
+    expect(createCommit).toHaveBeenCalledWith({
+      owner: 'acme',
+      repo: 'widgets',
+      message: 'chore: test',
+      tree: 'new-tree',
+      parents: ['base-sha'],
+    });
+    expect(octokit.git.createRef).toHaveBeenCalledWith({ owner: 'acme', repo: 'widgets', ref: 'refs/heads/accessmate/test', sha: 'commit-sha' });
+    expect(pullsCreate).toHaveBeenCalledWith({
+      owner: 'acme',
+      repo: 'widgets',
+      head: 'accessmate/test',
+      base: 'main',
+      title: 'Test PR',
+      body: 'Body',
+    });
+    expect(result).toEqual({
+      pullRequest: {
+        number: 7,
+        url: 'http://example/pr',
+        branch: 'accessmate/test',
+        headSha: 'commit-sha',
+      },
+    });
+  });
+
+  it('updates an existing branch without creating a new commit when no changes occur', async () => {
+    const { getRef, getCommit, createBlob, createTree, createCommit, pullsCreate } = createOctokitMocks();
+
+    getRef
+      .mockResolvedValueOnce({ data: { object: { sha: 'base-sha' } } })
+      .mockResolvedValueOnce({ data: { object: { sha: 'branch-sha' } } });
+    getCommit
+      .mockResolvedValueOnce({ data: { tree: { sha: 'base-tree' } } })
+      .mockResolvedValueOnce({ data: { tree: { sha: 'branch-tree' } } });
+    createBlob.mockResolvedValueOnce({ data: { sha: 'blob-sha' } });
+    createTree.mockResolvedValueOnce({ data: { sha: 'branch-tree' } });
+    pullsCreate.mockResolvedValueOnce({ data: { number: 9, html_url: 'http://example/pr2', head: { ref: 'accessmate/test' } } });
+
+    const result = await openPR(buildOptions());
+
+    expect(createCommit).not.toHaveBeenCalled();
+    expect(result.pullRequest.headSha).toBe('branch-sha');
+  });
+
+  it('returns existing PR metadata when the PR already exists', async () => {
+    const { getRef, getCommit, createBlob, createTree, createCommit, pullsCreate, pullsList } = createOctokitMocks();
+
+    getRef
+      .mockResolvedValueOnce({ data: { object: { sha: 'base-sha' } } })
+      .mockResolvedValueOnce({ data: { object: { sha: 'branch-sha' } } });
+    getCommit
+      .mockResolvedValueOnce({ data: { tree: { sha: 'base-tree' } } })
+      .mockResolvedValueOnce({ data: { tree: { sha: 'branch-tree' } } });
+    createBlob.mockResolvedValueOnce({ data: { sha: 'blob-sha' } });
+    createTree.mockResolvedValueOnce({ data: { sha: 'new-tree' } });
+    createCommit.mockResolvedValueOnce({ data: { sha: 'new-commit' } });
+    pullsCreate.mockRejectedValueOnce(Object.assign(new Error('exists'), { status: 422 }));
+    pullsList.mockResolvedValueOnce({
+      data: [
+        {
+          number: 15,
+          html_url: 'http://example/pr-existing',
+          head: { ref: 'accessmate/test' },
+        },
+      ],
+    });
+
+    const result = await openPR(buildOptions());
+
+    expect(result).toEqual({
+      pullRequest: {
+        number: 15,
+        url: 'http://example/pr-existing',
+        branch: 'accessmate/test',
+        headSha: 'new-commit',
+      },
+    });
+  });
+});

--- a/services/scm/src/index.ts
+++ b/services/scm/src/index.ts
@@ -1,3 +1,217 @@
-export async function openPR(opts: { repo: string; branch: string; title: string; body: string; }) {
-// TODO: use Octokit (installation token) to create branches/PRs and upload artifacts
+import { log } from '@accessmate/diagnostics';
+import { createGitHubApp, createInstallationClient } from '@accessmate/github';
+
+export interface OpenPRFileChange {
+  path: string;
+  content: string;
+  encoding?: 'utf-8' | 'base64';
+  mode?: '100644' | '100755';
+}
+
+export interface OpenPROptions {
+  repo: string;
+  branch: string;
+  baseBranch: string;
+  installationId: number;
+  title: string;
+  body: string;
+  commitMessage: string;
+  files: OpenPRFileChange[];
+}
+
+export interface OpenPRResult {
+  pullRequest: {
+    number: number;
+    url: string;
+    branch: string;
+    headSha: string;
+  };
+}
+
+function parseRepo(input: string): { owner: string; repo: string } {
+  const [owner, repo] = input.split('/');
+  if (!owner || !repo) {
+    throw new Error(`Invalid repo string: ${input}`);
+  }
+  return { owner, repo };
+}
+
+async function ensureBranch({
+  octokit,
+  owner,
+  repo,
+  branch,
+  newCommitSha,
+}: {
+  octokit: Awaited<ReturnType<typeof createInstallationClient>>;
+  owner: string;
+  repo: string;
+  branch: string;
+  newCommitSha: string;
+}): Promise<void> {
+  try {
+    await octokit.git.getRef({ owner, repo, ref: `heads/${branch}` });
+    await octokit.git.updateRef({ owner, repo, ref: `heads/${branch}`, sha: newCommitSha, force: false });
+  } catch (error) {
+    if (error && typeof error === 'object' && 'status' in error && error.status === 404) {
+      await octokit.git.createRef({ owner, repo, ref: `refs/heads/${branch}`, sha: newCommitSha });
+      return;
+    }
+
+    log.error('Failed to ensure branch reference', {
+      owner,
+      repo,
+      branch,
+      error: error instanceof Error ? error.message : 'unknown error',
+    });
+    throw error;
+  }
+}
+
+export async function openPR(opts: OpenPROptions): Promise<OpenPRResult> {
+  if (opts.files.length === 0) {
+    throw new Error('openPR requires at least one file change');
+  }
+
+  const appId = Number(process.env.GH_APP_ID);
+  const privateKey = process.env.GH_APP_PRIVATE_KEY;
+  if (!appId || !privateKey) {
+    throw new Error('GitHub App credentials are not configured');
+  }
+
+  const app = createGitHubApp({ appId, privateKey });
+  const octokit = await createInstallationClient({ app, installationId: opts.installationId });
+
+  const { owner, repo } = parseRepo(opts.repo);
+
+  try {
+    const baseRef = await octokit.git.getRef({ owner, repo, ref: `heads/${opts.baseBranch}` });
+    const baseCommitSha = baseRef.data.object.sha;
+    const baseCommit = await octokit.git.getCommit({ owner, repo, commit_sha: baseCommitSha });
+
+    let currentBranchSha: string | null = null;
+    try {
+      const existingBranch = await octokit.git.getRef({ owner, repo, ref: `heads/${opts.branch}` });
+      currentBranchSha = existingBranch.data.object.sha;
+    } catch (error) {
+      if (!(error && typeof error === 'object' && 'status' in error && error.status === 404)) {
+        throw error;
+      }
+    }
+
+    const parentSha = currentBranchSha ?? baseCommitSha;
+    const parentCommit = await octokit.git.getCommit({ owner, repo, commit_sha: parentSha });
+
+    const dedupedFiles = Array.from(
+      opts.files.reduce((map, file) => map.set(file.path, file), new Map<string, OpenPRFileChange>()).values(),
+    );
+
+    const blobs = await Promise.all(
+      dedupedFiles.map((file) =>
+        octokit.git.createBlob({
+          owner,
+          repo,
+          content: file.content,
+          encoding: file.encoding ?? 'utf-8',
+        }),
+      ),
+    );
+
+    const treeResponse = await octokit.git.createTree({
+      owner,
+      repo,
+      base_tree: parentCommit.data.tree.sha,
+      tree: blobs.map((blob, index) => ({
+        path: dedupedFiles[index]!.path,
+        mode: dedupedFiles[index]!.mode ?? '100644',
+        type: 'blob',
+        sha: blob.data.sha,
+      })),
+    });
+
+    let headSha = parentSha;
+    if (treeResponse.data.sha !== parentCommit.data.tree.sha) {
+      const commit = await octokit.git.createCommit({
+        owner,
+        repo,
+        message: opts.commitMessage,
+        tree: treeResponse.data.sha,
+        parents: [parentSha],
+      });
+      headSha = commit.data.sha;
+      await ensureBranch({
+        octokit,
+        owner,
+        repo,
+        branch: opts.branch,
+        newCommitSha: headSha,
+      });
+    } else if (!currentBranchSha) {
+      // No existing branch and no changes -> still create branch at parent
+      await ensureBranch({
+        octokit,
+        owner,
+        repo,
+        branch: opts.branch,
+        newCommitSha: parentSha,
+      });
+    }
+
+    let prResponse;
+    try {
+      prResponse = await octokit.pulls.create({
+        owner,
+        repo,
+        head: opts.branch,
+        base: opts.baseBranch,
+        title: opts.title,
+        body: opts.body,
+      });
+    } catch (error) {
+      if (error && typeof error === 'object' && 'status' in error && error.status === 422) {
+        const existing = await octokit.pulls.list({
+          owner,
+          repo,
+          head: `${owner}:${opts.branch}`,
+          state: 'open',
+        });
+        const match = existing.data.find((pr) => pr.head.ref === opts.branch);
+        if (!match) {
+          throw error;
+        }
+        return {
+          pullRequest: {
+            number: match.number,
+            url: match.html_url,
+            branch: opts.branch,
+            headSha,
+          },
+        };
+      }
+
+      log.error('Failed to create pull request', {
+        owner,
+        repo,
+        branch: opts.branch,
+        error: error instanceof Error ? error.message : 'unknown error',
+      });
+      throw error;
+    }
+
+    return {
+      pullRequest: {
+        number: prResponse.data.number,
+        url: prResponse.data.html_url,
+        branch: prResponse.data.head.ref,
+        headSha,
+      },
+    };
+  } catch (error) {
+    log.error('Failed to open PR', {
+      repo: opts.repo,
+      branch: opts.branch,
+      error: error instanceof Error ? error.message : 'unknown error',
+    });
+    throw error;
+  }
 }

--- a/services/scm/tsconfig.json
+++ b/services/scm/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/services/scm/vitest.config.ts
+++ b/services/scm/vitest.config.ts
@@ -1,0 +1,18 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const resolvePath = (...segments: string[]) =>
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), ...segments);
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@accessmate/diagnostics': resolvePath('../../libs/diagnostics/src/index.ts'),
+      '@accessmate/github': resolvePath('../../libs/github/src/index.ts'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a fully functional SCM service that authenticates as the GitHub App installation, applies file changes, and opens pull requests
- extend the in-memory persistence layer with project, installation, file change, and PR reference storage and invoke it from the orchestrator worker
- wire up Vitest configs and author unit tests that cover the SCM branch/PR workflow and orchestrator integration

## Testing
- pnpm --filter @accessmate/scm test
- pnpm --filter @accessmate/orchestrator test

------
https://chatgpt.com/codex/tasks/task_e_68d783a3c51c8321b9b2901673c40092