### PR TITLE
feat: add RAG service for WCAG references

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,13 +258,44 @@ importers:
       '@accessmate/queue':
         specifier: workspace:*
         version: link:../../libs/queue
+      '@accessmate/rag':
+        specifier: workspace:*
+        version: link:../rag
+      bullmq:
+        specifier: ^5.7.5
+        version: 5.58.9
     devDependencies:
+      '@types/node':
+        specifier: ^20.19.17
+        version: 20.19.17
       tsx:
         specifier: ^4.17.0
         version: 4.20.6
       typescript:
         specifier: ^5.5.4
         version: 5.9.2
+
+  services/rag:
+    dependencies:
+      '@accessmate/db':
+        specifier: workspace:*
+        version: link:../../libs/db
+      '@accessmate/diagnostics':
+        specifier: workspace:*
+        version: link:../../libs/diagnostics
+      '@accessmate/wcag':
+        specifier: workspace:*
+        version: link:../../libs/wcag
+    devDependencies:
+      '@types/node':
+        specifier: ^20.19.17
+        version: 20.19.17
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.2
+        version: 2.1.9(@types/node@20.19.17)
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 packages:
-- "apps/*"
-- "services/*"
-- "libs/*"
+  - "apps/*"
+  - "services/*"
+  - "libs/*"

--- a/services/orchestrator/package.json
+++ b/services/orchestrator/package.json
@@ -12,9 +12,12 @@
     "@accessmate/diagnostics": "workspace:*",
     "@accessmate/persistence": "workspace:*",
     "@accessmate/queue": "workspace:*",
-    "@accessmate/core-types": "workspace:*"
+    "@accessmate/core-types": "workspace:*",
+    "@accessmate/rag": "workspace:*",
+    "bullmq": "^5.7.5"
   },
   "devDependencies": {
+    "@types/node": "^20.19.17",
     "tsx": "^4.17.0",
     "typescript": "^5.5.4"
   }

--- a/services/orchestrator/src/worker.ts
+++ b/services/orchestrator/src/worker.ts
@@ -4,6 +4,7 @@ import { Job } from 'bullmq';
 import { log } from '@accessmate/diagnostics';
 import type { Finding } from '@accessmate/core-types';
 import { runAudit } from '@accessmate/dynamic-audit';
+import { retrieveGuidelines } from '@accessmate/rag';
 import { getRun, saveFindings, updateRun } from '@accessmate/persistence';
 import {
   assertQueueJob,
@@ -97,6 +98,18 @@ createJobWorker(
 
             for (const violation of result.violations) {
               const firstNode = violation.nodes[0];
+              const references = await retrieveGuidelines({
+                ruleId: violation.id,
+                contextSnippet: firstNode?.html ?? violation.description,
+              });
+              const topReference = references[0];
+              const referenceText = topReference
+                ? `${topReference.citation} — ${topReference.summary}`
+                : undefined;
+              const wcagRef = referenceText
+                ? `${referenceText}${violation.helpUrl ? ` (${violation.helpUrl})` : ''}`
+                : violation.helpUrl;
+
               findings.push({
                 id: randomUUID(),
                 runId,
@@ -104,7 +117,7 @@ createJobWorker(
                 severity: impactToSeverity(violation.impact),
                 selector: firstNode?.target?.[0],
                 snippet: firstNode?.html,
-                wcagRef: violation.helpUrl,
+                wcagRef,
               });
             }
           }

--- a/services/orchestrator/tsconfig.json
+++ b/services/orchestrator/tsconfig.json
@@ -2,7 +2,25 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "types": ["node"]
+    "types": ["node"],
+    "paths": {
+      "@accessmate/diagnostics": ["../../libs/diagnostics/src"],
+      "@accessmate/diagnostics/*": ["../../libs/diagnostics/src/*"],
+      "@accessmate/core-types": ["../../libs/core-types/src"],
+      "@accessmate/core-types/*": ["../../libs/core-types/src/*"],
+      "@accessmate/dynamic-audit": ["../dynamic-audit/src"],
+      "@accessmate/dynamic-audit/*": ["../dynamic-audit/src/*"],
+      "@accessmate/persistence": ["../../libs/persistence/src"],
+      "@accessmate/persistence/*": ["../../libs/persistence/src/*"],
+      "@accessmate/queue": ["../../libs/queue/src"],
+      "@accessmate/queue/*": ["../../libs/queue/src/*"],
+      "@accessmate/db": ["../../libs/db/src"],
+      "@accessmate/db/*": ["../../libs/db/src/*"],
+      "@accessmate/wcag": ["../../libs/wcag/src"],
+      "@accessmate/wcag/*": ["../../libs/wcag/src/*"],
+      "@accessmate/rag": ["../rag/src"],
+      "@accessmate/rag/*": ["../rag/src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/services/rag/Dockerfile
+++ b/services/rag/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.7
+FROM node:20-alpine AS base
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable
+
+FROM base AS deps
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml tsconfig.base.json ./
+COPY libs ./libs
+COPY services/rag/package.json ./services/rag/package.json
+RUN pnpm install --frozen-lockfile --filter @accessmate/rag...
+
+FROM deps AS build
+RUN pnpm --filter @accessmate/rag build
+
+FROM base AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=build /app/services/rag/dist ./dist
+COPY services/rag/package.json ./package.json
+CMD ["node", "dist/server.js"]

--- a/services/rag/package.json
+++ b/services/rag/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@accessmate/rag",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@accessmate/db": "workspace:*",
+    "@accessmate/diagnostics": "workspace:*",
+    "@accessmate/wcag": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.19.17",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.2"
+  }
+}

--- a/services/rag/src/index.ts
+++ b/services/rag/src/index.ts
@@ -1,0 +1,3 @@
+export type { QueryInput, GuidelineMatch } from './ingest.js';
+export { retrieveGuidelines, ensureGuidelineIndex, GuidelineIndex } from './ingest.js';
+export { createHttpServer, startServer } from './server.js';

--- a/services/rag/src/ingest.test.ts
+++ b/services/rag/src/ingest.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { GuidelineIndex, __testing } from './ingest.js';
+
+const { buildGuidelinesFromChecklist, parseWcagReference } = __testing;
+
+describe('parseWcagReference', () => {
+  it('extracts the WCAG code and title from combined strings', () => {
+    const parsed = parseWcagReference('3.1.5 Reading Level');
+    expect(parsed.code).toBe('3.1.5');
+    expect(parsed.title).toBe('Reading Level');
+  });
+
+  it('falls back to the original value when parsing fails', () => {
+    const parsed = parseWcagReference('Non standard value');
+    expect(parsed.code).toBe('Non standard value');
+    expect(parsed.title).toBe('');
+  });
+});
+
+describe('GuidelineIndex', () => {
+  const guidelines = buildGuidelinesFromChecklist();
+  const index = new GuidelineIndex(guidelines);
+
+  it('limits the number of matches returned', () => {
+    const matches = index.search({ contextSnippet: 'form label accessible name' }, 2);
+    expect(matches).toHaveLength(2);
+    expect(matches[0].score).toBeGreaterThan(0);
+    expect(matches[0].score).toBeGreaterThanOrEqual(matches[1].score);
+  });
+
+  it('boosts guidelines that match WCAG codes in the query text', () => {
+    const matches = index.search(
+      {
+        ruleId: 'color-contrast',
+        contextSnippet: 'Contrast issue fails WCAG 1.4.3 on text elements',
+      },
+      3,
+    );
+
+    expect(matches[0].wcagCode).toBe('1.4.3');
+    expect(matches[0].citation).toContain('WCAG 1.4.3');
+  });
+});

--- a/services/rag/src/ingest.ts
+++ b/services/rag/src/ingest.ts
@@ -1,0 +1,424 @@
+import { Buffer } from 'node:buffer';
+import { createHash } from 'node:crypto';
+import { log } from '@accessmate/diagnostics';
+import { prisma } from '@accessmate/db';
+import type { Prisma } from '@accessmate/db';
+import { wcagChecklist } from '@accessmate/wcag';
+
+const SOURCE_KEY = '@accessmate/wcag/checklist';
+const EMBEDDING_DIMENSION = 256;
+const STOP_WORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'but',
+  'by',
+  'for',
+  'from',
+  'has',
+  'have',
+  'in',
+  'is',
+  'it',
+  'its',
+  'of',
+  'on',
+  'or',
+  'that',
+  'the',
+  'to',
+  'was',
+  'were',
+  'with',
+]);
+
+export type QueryInput = {
+  ruleId?: string;
+  contextSnippet?: string;
+};
+
+export interface GuidelineMatch {
+  id: string;
+  topic: string;
+  wcagCode: string;
+  wcagTitle: string;
+  paragraph: string;
+  summary: string;
+  citation: string;
+  source: string;
+  score: number;
+}
+
+type NormalizedGuideline = Omit<GuidelineMatch, 'score'> & {
+  embedding: Float32Array;
+};
+
+let cachedIndexPromise: Promise<GuidelineIndex> | null = null;
+
+export class GuidelineIndex {
+  constructor(private readonly guidelines: NormalizedGuideline[]) {}
+
+  search(query: QueryInput, limit = 5): GuidelineMatch[] {
+    const queryText = buildQueryText(query);
+    const queryVector = embedText(queryText);
+    const wcagCodes = extractWcagCodes(queryText);
+    const normalizedRule = query.ruleId ? normalizeRuleId(query.ruleId) : null;
+
+    const matches = this.guidelines
+      .map((guideline) => {
+        const similarity = cosineSimilarity(queryVector, guideline.embedding);
+        const bonus = computeMetadataBonus(guideline, wcagCodes, normalizedRule);
+        return {
+          ...guideline,
+          score: similarity + bonus,
+        } satisfies GuidelineMatch;
+      })
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
+
+    return matches;
+  }
+}
+
+export async function ensureGuidelineIndex(): Promise<GuidelineIndex> {
+  if (!cachedIndexPromise) {
+    cachedIndexPromise = loadIndex();
+  }
+
+  return cachedIndexPromise;
+}
+
+export async function retrieveGuidelines(
+  query: QueryInput,
+  options?: { limit?: number },
+): Promise<GuidelineMatch[]> {
+  const index = await ensureGuidelineIndex();
+  const limit = options?.limit ?? 5;
+  return index.search(query, limit);
+}
+
+async function loadIndex(): Promise<GuidelineIndex> {
+  const fromDatabase = await loadFromDatabase();
+  if (fromDatabase) {
+    return new GuidelineIndex(fromDatabase);
+  }
+
+  const fromChecklist = buildGuidelinesFromChecklist();
+  await persistGuidelines(fromChecklist);
+  return new GuidelineIndex(fromChecklist);
+}
+
+async function loadFromDatabase(): Promise<NormalizedGuideline[] | null> {
+  if (!process.env.DATABASE_URL) {
+    return null;
+  }
+
+  try {
+    const records = await prisma.guidelineChunk.findMany({
+      where: { source: SOURCE_KEY },
+    });
+
+    if (records.length === 0) {
+      return null;
+    }
+
+    const parsed: NormalizedGuideline[] = [];
+    for (const record of records) {
+      try {
+        const payload = JSON.parse(record.body);
+        if (!isPersistedPayload(payload)) {
+          return null;
+        }
+
+        const buffer = record.embedding as unknown as Buffer;
+        const bytes = buffer.buffer.slice(
+          buffer.byteOffset,
+          buffer.byteOffset + buffer.byteLength,
+        );
+        if (bytes.byteLength !== EMBEDDING_DIMENSION * 4) {
+          return null;
+        }
+
+        const embedding = new Float32Array(bytes);
+        normalizeVector(embedding);
+
+        parsed.push({
+          id: record.id,
+          source: SOURCE_KEY,
+          topic: payload.topic,
+          wcagCode: payload.wcagCode,
+          wcagTitle: payload.wcagTitle,
+          paragraph: payload.paragraph,
+          summary: payload.summary,
+          citation: payload.citation,
+          embedding,
+        });
+      } catch (error) {
+        log.warn('Failed to parse persisted guideline chunk, rebuilding from checklist', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+      }
+    }
+
+    if (parsed.length === 0) {
+      return null;
+    }
+
+    return parsed;
+  } catch (error) {
+    log.warn('Unable to load WCAG index from database, falling back to in-memory version', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+async function persistGuidelines(guidelines: NormalizedGuideline[]): Promise<void> {
+  if (!process.env.DATABASE_URL) {
+    return;
+  }
+
+  try {
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+      await tx.guidelineChunk.deleteMany({ where: { source: SOURCE_KEY } });
+      for (const guideline of guidelines) {
+        await tx.guidelineChunk.create({
+          data: {
+            source: SOURCE_KEY,
+            heading: guideline.citation,
+            body: JSON.stringify({
+              topic: guideline.topic,
+              wcagCode: guideline.wcagCode,
+              wcagTitle: guideline.wcagTitle,
+              paragraph: guideline.paragraph,
+              summary: guideline.summary,
+              citation: guideline.citation,
+            }),
+            embedding: Buffer.from(guideline.embedding.buffer),
+          },
+        });
+      }
+    });
+  } catch (error) {
+    log.warn('Unable to persist WCAG index, continuing with in-memory fallback', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+type ChecklistEntry = {
+  task: string;
+  wcag: string;
+};
+
+function buildGuidelinesFromChecklist(): NormalizedGuideline[] {
+  const guidelines: NormalizedGuideline[] = [];
+  const seen = new Set<string>();
+  const checklist = wcagChecklist.checklist as Record<string, ChecklistEntry[]>;
+
+  for (const [topic, entries] of Object.entries(checklist)) {
+    for (const entry of entries) {
+      const paragraph = entry.task.trim();
+      const { code, title } = parseWcagReference(entry.wcag);
+      const citation = title ? `WCAG ${code} ${title}` : `WCAG ${code}`;
+      const id = createHash('sha1')
+        .update(`${topic}:${entry.wcag}:${paragraph}`)
+        .digest('hex');
+
+      if (seen.has(id)) {
+        continue;
+      }
+      seen.add(id);
+
+      const text = `${topic} ${code} ${title} ${paragraph}`;
+      const embedding = embedText(text);
+
+      guidelines.push({
+        id,
+        source: SOURCE_KEY,
+        topic,
+        wcagCode: code,
+        wcagTitle: title,
+        paragraph,
+        summary: paragraph,
+        citation,
+        embedding,
+      });
+    }
+  }
+
+  return guidelines;
+}
+
+function parseWcagReference(input: string): { code: string; title: string } {
+  const match = input.match(/^(\d(?:\.\d+)+)\s*(.*)$/);
+  if (match) {
+    return {
+      code: match[1],
+      title: match[2]?.trim() ?? '',
+    };
+  }
+
+  return { code: input.trim(), title: '' };
+}
+
+function embedText(text: string): Float32Array {
+  const vector = new Float32Array(EMBEDDING_DIMENSION);
+  const tokens = tokenize(text);
+  if (tokens.length === 0) {
+    return vector;
+  }
+
+  for (const token of tokens) {
+    const index = hashToken(token);
+    vector[index] += 1;
+  }
+
+  return normalizeVector(vector);
+}
+
+function normalizeVector(vector: Float32Array): Float32Array {
+  let norm = 0;
+  for (let i = 0; i < vector.length; i += 1) {
+    norm += vector[i] * vector[i];
+  }
+
+  if (norm === 0) {
+    return vector;
+  }
+
+  const magnitude = Math.sqrt(norm);
+  for (let i = 0; i < vector.length; i += 1) {
+    vector[i] = vector[i] / magnitude;
+  }
+
+  return vector;
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9.]+/g, ' ')
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0)
+    .filter((token) => !STOP_WORDS.has(token));
+}
+
+function hashToken(token: string): number {
+  const digest = createHash('sha1').update(token).digest();
+  const bucket = digest.readUInt32BE(0);
+  return bucket % EMBEDDING_DIMENSION;
+}
+
+function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < a.length; i += 1) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+
+  if (normA === 0 || normB === 0) {
+    return 0;
+  }
+
+  return dot / Math.sqrt(normA * normB);
+}
+
+function buildQueryText(query: QueryInput): string {
+  const parts: string[] = [];
+  if (query.ruleId) {
+    parts.push(normalizeRuleId(query.ruleId));
+  }
+  if (query.contextSnippet) {
+    parts.push(query.contextSnippet);
+  }
+  return parts.join(' ');
+}
+
+function normalizeRuleId(ruleId: string): string {
+  return ruleId.replace(/[-_]+/g, ' ').toLowerCase();
+}
+
+function extractWcagCodes(text: string): Set<string> {
+  const codes = new Set<string>();
+  const regex = /(\d(?:\.\d+)+)/g;
+  let match: RegExpExecArray | null;
+  // eslint-disable-next-line no-cond-assign
+  while ((match = regex.exec(text))) {
+    codes.add(match[1]);
+  }
+  return codes;
+}
+
+function computeMetadataBonus(
+  guideline: NormalizedGuideline,
+  wcagCodes: Set<string>,
+  normalizedRule: string | null,
+): number {
+  let bonus = 0;
+
+  if (wcagCodes.has(guideline.wcagCode)) {
+    bonus += 0.5;
+  }
+
+  if (normalizedRule) {
+    const normalizedTopic = guideline.topic.toLowerCase();
+    const normalizedTitle = guideline.wcagTitle.toLowerCase();
+    const normalizedParagraph = guideline.paragraph.toLowerCase();
+
+    if (normalizedParagraph.includes(normalizedRule)) {
+      bonus += 0.3;
+    } else if (normalizedTitle.includes(normalizedRule)) {
+      bonus += 0.2;
+    } else if (normalizedTopic.includes(normalizedRule)) {
+      bonus += 0.1;
+    }
+  }
+
+  return bonus;
+}
+
+function isPersistedPayload(value: unknown): value is {
+  topic: string;
+  wcagCode: string;
+  wcagTitle: string;
+  paragraph: string;
+  summary: string;
+  citation: string;
+} {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const payload = value as Record<string, unknown>;
+  return (
+    typeof payload.topic === 'string' &&
+    typeof payload.wcagCode === 'string' &&
+    typeof payload.wcagTitle === 'string' &&
+    typeof payload.paragraph === 'string' &&
+    typeof payload.summary === 'string' &&
+    typeof payload.citation === 'string'
+  );
+}
+
+export const __testing = {
+  buildGuidelinesFromChecklist,
+  parseWcagReference,
+  embedText,
+  tokenize,
+  computeMetadataBonus,
+  buildQueryText,
+  extractWcagCodes,
+  cosineSimilarity,
+  normalizeRuleId,
+};

--- a/services/rag/src/server.ts
+++ b/services/rag/src/server.ts
@@ -1,0 +1,74 @@
+import { Buffer } from 'node:buffer';
+import { createServer, IncomingMessage, ServerResponse } from 'node:http';
+import { log } from '@accessmate/diagnostics';
+import { retrieveGuidelines, type QueryInput } from './ingest.js';
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    request.on('data', (chunk) => {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+    });
+    request.on('end', () => {
+      resolve(Buffer.concat(chunks).toString('utf8'));
+    });
+    request.on('error', (error) => reject(error));
+  });
+}
+
+async function handleQuery(request: IncomingMessage, response: ServerResponse): Promise<void> {
+  try {
+    const rawBody = await readBody(request);
+    const payload = rawBody.length > 0 ? JSON.parse(rawBody) : {};
+    const query = normalizeQueryInput(payload);
+
+    const matches = await retrieveGuidelines(query, { limit: payload?.limit ?? 5 });
+
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.end(JSON.stringify({ matches }));
+  } catch (error) {
+    log.error('Failed to handle retrieval request', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    response.writeHead(400, { 'Content-Type': 'application/json' });
+    response.end(
+      JSON.stringify({
+        error: 'Invalid request payload',
+      }),
+    );
+  }
+}
+
+function normalizeQueryInput(payload: any): QueryInput {
+  const query: QueryInput = {};
+  if (payload && typeof payload.ruleId === 'string') {
+    query.ruleId = payload.ruleId;
+  }
+  if (payload && typeof payload.contextSnippet === 'string') {
+    query.contextSnippet = payload.contextSnippet;
+  }
+  return query;
+}
+
+export function createHttpServer() {
+  return createServer(async (request, response) => {
+    if (request.method === 'POST' && request.url === '/query') {
+      await handleQuery(request, response);
+      return;
+    }
+
+    response.writeHead(404, { 'Content-Type': 'application/json' });
+    response.end(JSON.stringify({ error: 'Not Found' }));
+  });
+}
+
+export async function startServer(port = Number(process.env.PORT ?? 4100)) {
+  const server = createHttpServer();
+  await new Promise<void>((resolve) => {
+    server.listen(port, () => {
+      log.info('RAG retrieval server listening', { port });
+      resolve();
+    });
+  });
+  return server;
+}

--- a/services/rag/test/db-stub.ts
+++ b/services/rag/test/db-stub.ts
@@ -1,0 +1,12 @@
+type TransactionCallback<T> = (tx: typeof prisma) => Promise<T>;
+
+export const prisma = {
+  guidelineChunk: {
+    findMany: async () => [] as unknown[],
+    deleteMany: async () => {},
+    create: async () => {},
+  },
+  $transaction: async <T>(callback: TransactionCallback<T>) => {
+    return callback(prisma);
+  },
+};

--- a/services/rag/tsconfig.json
+++ b/services/rag/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node"],
+    "paths": {
+      "@accessmate/diagnostics": ["../../libs/diagnostics/src"],
+      "@accessmate/diagnostics/*": ["../../libs/diagnostics/src/*"],
+      "@accessmate/db": ["../../libs/db/src"],
+      "@accessmate/db/*": ["../../libs/db/src/*"],
+      "@accessmate/wcag": ["../../libs/wcag/src"],
+      "@accessmate/wcag/*": ["../../libs/wcag/src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/services/rag/vitest.config.ts
+++ b/services/rag/vitest.config.ts
@@ -1,0 +1,19 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@accessmate/diagnostics': resolve(__dirname, '../../libs/diagnostics/src/index.ts'),
+      '@accessmate/wcag': resolve(__dirname, '../../libs/wcag/src/index.ts'),
+      '@accessmate/db': resolve(__dirname, './test/db-stub.ts'),
+    },
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     { "path": "./apps/github-app" },
     { "path": "./apps/web" },
     { "path": "./services/dynamic-audit" },
+    { "path": "./services/rag" },
     { "path": "./services/orchestrator" },
     { "path": "./services/scm" }
   ]


### PR DESCRIPTION
## Summary
- add a new @accessmate/rag service with ingestion, similarity search, and an HTTP query endpoint backed by a hashed WCAG guideline index
- cover the RAG scoring and chunking logic with Vitest unit tests and provide local testing config
- wire the orchestrator worker to request WCAG guidance for each violation and update configs/dependencies for the new package

## Testing
- pnpm --filter @accessmate/rag test
- pnpm --filter @accessmate/rag build
- pnpm --filter @accessmate/orchestrator build

------
https://chatgpt.com/codex/tasks/task_e_68d7835496588321b0467caadfa9524d